### PR TITLE
Add configurable max image pixels for PDF processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ ENV/
 # Rope project settings
 .ropeproject
 /.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For a quick installation, there is a docker version available. See the examples 
 
 If you don't like docker, there is the manual installation option.
 If you already installed [rest_uploader](https://github.com/kellerjustin/rest-uploader) you probably almost setup already.
-All that is left is to install this scrip and setup the environment variables.
+All that is left is to install this script and setup the environment variables.
 
 ```shell
 pip install ocr-joplin-notes
@@ -111,6 +111,12 @@ For Windows and Mac users, the workaround is to add the `JOPLIN_SERVER` environm
 ```
 JOPLIN_SERVER=http://host.docker.internal:41184
 # It also works with JOPLIN_SERVER=http://gateway.docker.internal:41184 as the docs indicate
+```
+**Optional Max image pixels environment variable**
+The OCR process for PDFs will experience errors and stop if your PDFs have large images contained within the file.  There is a tunable parameter that allows you to process larger files without errors in exchange for higher memory usage.  You can tune this parameter by setting the environment variable MAX_IMAGE_PIXELS in your docker-env file. The default max is 178956970. (this default size can cause errors with PDFs as small as 3MB, so if you experience these errors, you can experiment with increasing the value as seen in the example below)
+
+```
+MAX_IMAGE_PIXELS=400000000
 ```
 
 ### Still to do

--- a/ocr_joplin_notes/file_ocr.py
+++ b/ocr_joplin_notes/file_ocr.py
@@ -7,6 +7,14 @@ import numpy as np
 
 import PyPDF2
 from PIL import Image
+# large images within PDFs cause a decompression bomb error (a form of protection from abuse)
+# this setting allows the user to configure how large an image they are comfortable processing
+# The tradeoff to a large max size here is memory consumption, which the user can self-regulate
+# using this setting.  If they do not set the variable, it remains at the default for PIL.
+
+MAX_IMAGE_PIXELS = os.environ.get('MAX_IMAGE_PIXELS',178956970) # this is the default PIL max size
+Image.MAX_IMAGE_PIXELS = int(MAX_IMAGE_PIXELS)
+
 from pdf2image import convert_from_path
 from pytesseract import image_to_string, TesseractError
 


### PR DESCRIPTION
Large images within PDFs cause a decompression bomb error (a form of protection from abuse)
I've added a configurable setting via environment variable that allows the user to configure how large an image they are comfortable processing.  The tradeoff to a large max size here is memory consumption, which the user can self-regulate using this setting.  If they do not set the variable, it remains at the same default it was prior to this change.

~~@plamola, this works correctly in python, but I'm unable to test this in Docker to make sure the environment variable comes through correctly there as well (the dockerfile pulls directly from your python repository and I've been unable to test pulling it from my github changes, so can you please double-check that the environment variable passes correctly from Docker on your end?)~~

Edit: I figured out how to create a local docker image with my python code and it works as expected. Should be good to merge once you review.